### PR TITLE
Fix bug reading tar files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,7 +167,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 endif()
 
 include("${PCL_SOURCE_DIR}/cmake/pcl_utils.cmake")
-set(PCL_VERSION 1.7.2 CACHE STRING "PCL version")
+set(PCL_VERSION 1.7.2.1 CACHE STRING "PCL version")
 DISSECT_VERSION()
 GET_OS_INFO()
 SET_INSTALL_DIRS()

--- a/recognition/include/pcl/recognition/impl/linemod/line_rgbd.hpp
+++ b/recognition/include/pcl/recognition/impl/linemod/line_rgbd.hpp
@@ -119,7 +119,6 @@ pcl::LineRGBD<PointXYZT, PointRGBT>::loadTemplates (const std::string &file_name
       pcd_reader.read (file_name, template_point_clouds_[template_point_clouds_.size () - 1], ltm_offset);
 
       // Increment the offset for the next file
-      //ltm_offset += (ltm_header.getFileSize ()) + (512 - ltm_header.getFileSize () % 512);
       ltm_offset += (ltm_header.getFileSize ());
       if (ltm_header.getFileSize () % 512) {
         ltm_offset += (512 - ltm_header.getFileSize () % 512);
@@ -150,7 +149,6 @@ pcl::LineRGBD<PointXYZT, PointRGBT>::loadTemplates (const std::string &file_name
       object_ids_.push_back (object_id);
 
       // Increment the offset for the next file
-      //ltm_offset += (ltm_header.getFileSize ()) + (512 - ltm_header.getFileSize () % 512);
       ltm_offset += (ltm_header.getFileSize ());
       if (ltm_header.getFileSize () % 512) {
         ltm_offset += (512 - ltm_header.getFileSize () % 512);

--- a/recognition/include/pcl/recognition/impl/linemod/line_rgbd.hpp
+++ b/recognition/include/pcl/recognition/impl/linemod/line_rgbd.hpp
@@ -119,7 +119,11 @@ pcl::LineRGBD<PointXYZT, PointRGBT>::loadTemplates (const std::string &file_name
       pcd_reader.read (file_name, template_point_clouds_[template_point_clouds_.size () - 1], ltm_offset);
 
       // Increment the offset for the next file
-      ltm_offset += (ltm_header.getFileSize ()) + (512 - ltm_header.getFileSize () % 512);
+      //ltm_offset += (ltm_header.getFileSize ()) + (512 - ltm_header.getFileSize () % 512);
+      ltm_offset += (ltm_header.getFileSize ());
+      if (ltm_header.getFileSize () % 512) {
+        ltm_offset += (512 - ltm_header.getFileSize () % 512);
+      }
     }
     else if ((it = chunk_name.find (sqmmt_ext)) != std::string::npos &&
              (sqmmt_ext.size () - (chunk_name.size () - it)) == 0)
@@ -146,7 +150,11 @@ pcl::LineRGBD<PointXYZT, PointRGBT>::loadTemplates (const std::string &file_name
       object_ids_.push_back (object_id);
 
       // Increment the offset for the next file
-      ltm_offset += (ltm_header.getFileSize ()) + (512 - ltm_header.getFileSize () % 512);
+      //ltm_offset += (ltm_header.getFileSize ()) + (512 - ltm_header.getFileSize () % 512);
+      ltm_offset += (ltm_header.getFileSize ());
+      if (ltm_header.getFileSize () % 512) {
+        ltm_offset += (512 - ltm_header.getFileSize () % 512);
+      }
 
       delete [] buffer;
     }


### PR DESCRIPTION
LineRGBD::LoadTemplates reads a tar file containing .pcd and .sqmmt files.  The tar file spec requires each file header to start at a multiple of 512 bytes, however, the old version of this function takes and extra 512 byte step in the tar file when it finishes reading a file with a length that is an exact multiple of 512 bytes.  This pull fixes that bug.

To facilitate using multiple version of PCL, the version of PCL is incremented to 1.7.2.1 (as this is a branch of 1.7.2).